### PR TITLE
Fix CSV parsing whitespace and dashboard chart data

### DIFF
--- a/dist/src/utils/csv.js
+++ b/dist/src/utils/csv.js
@@ -46,7 +46,7 @@ function parseCSV(text) {
     return dataLines.map((line, idx) => {
         const values = line
             .split(/,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/)
-            .map((v) => v.replace(/^\"|\"$/g, "").replace(/\"\"/g, "\""));
+            .map((v) => v.trim().replace(/^\"|\"$/g, "").replace(/\"\"/g, "\""));
         if (values.length !== headers.length) {
             throw new Error(`Row ${idx + 1} has ${values.length} columns, expected ${headers.length}`);
         }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -32,13 +32,13 @@ export function Dashboard({ requirements, coveragePercent, isReady }: Props) {
             <ResponsiveContainer>
               <PieChart>
                 <Pie
-                  data={requirements.map((r) => ({ name: r.status, value: 1 }))}
+                  data={pieData}
                   innerRadius={60}
                   outerRadius={80}
                   dataKey="value"
                   nameKey="name"
                 >
-                  {requirements.map((_, index) => (
+                  {pieData.map((_, index) => (
                     <Cell key={index} fill={COLORS[index % COLORS.length]} />
                   ))}
                 </Pie>

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -43,7 +43,9 @@ export function parseCSV(text: string): Requirement[] {
   return dataLines.map((line, idx) => {
     const values = line
       .split(/,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/)
-      .map((v) => v.replace(/^\"|\"$/g, "").replace(/\"\"/g, "\""));
+      .map((v) =>
+        v.trim().replace(/^\"|\"$/g, "").replace(/\"\"/g, "\"")
+      );
     if (values.length !== headers.length) {
       throw new Error(
         `Row ${idx + 1} has ${values.length} columns, expected ${headers.length}`


### PR DESCRIPTION
## Summary
- trim CSV cell values when importing to avoid leading spaces
- show requirement counts in dashboard pie chart instead of each item individually

## Testing
- `npx tsc`
- `node tests/csv.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6841b4f900a48328b40020e338c2d82d