### PR TITLE
Fix imports by adding local UI components

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { Button } from "./src/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -8,15 +8,15 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+} from "./src/components/ui/dialog";
+import { Input } from "./src/components/ui/input";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from "./src/components/ui/select";
 import { Plus, Save, Search, Upload, Download } from "lucide-react";
 import { Requirement, STATUSES, Status } from "./src/types";
 import { SAMPLE_REQUIREMENTS } from "./src/sampleData";

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "lucide-react": "^0.355.0"
+    "lucide-react": "^0.355.0",
+    "recharts": "^2.8.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,7 +4,7 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from "./ui/card";
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 
 const COLORS = ["#0097D5", "#00C49F", "#FFBB28", "#FF8042", "#8884D8"];

--- a/src/components/RequirementList.tsx
+++ b/src/components/RequirementList.tsx
@@ -4,16 +4,16 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+} from "./ui/card";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from "./ui/select";
 import { Trash } from "lucide-react";
 
 interface Props {

--- a/src/components/SpecTree.tsx
+++ b/src/components/SpecTree.tsx
@@ -1,6 +1,6 @@
 import { Requirement } from "../types";
 import { SPEC_TREE } from "../sampleData";
-import { Button } from "@/components/ui/button";
+import { Button } from "./ui/button";
 import { Trash } from "lucide-react";
 
 interface Props {

--- a/src/components/TraceMatrix.tsx
+++ b/src/components/TraceMatrix.tsx
@@ -4,8 +4,8 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+} from "./ui/card";
+import { Button } from "./ui/button";
 import { Trash } from "lucide-react";
 
 interface Props {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,10 @@
+import { ButtonHTMLAttributes } from "react";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: string;
+  size?: string;
+}
+
+export function Button({ variant, size, ...props }: ButtonProps) {
+  return <button {...props} />;
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,17 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+export function Card({ children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div {...props}>{children}</div>;
+}
+
+export function CardHeader({ children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div {...props}>{children}</div>;
+}
+
+export function CardTitle({ children, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 {...props}>{children}</h2>;
+}
+
+export function CardContent({ children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div {...props}>{children}</div>;
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,29 @@
+import { ReactNode, HTMLAttributes, ButtonHTMLAttributes } from "react";
+
+export function Dialog({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+export function DialogTrigger(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <button {...props} />;
+}
+
+export function DialogContent({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+export function DialogHeader({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+export function DialogFooter({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+export function DialogTitle({ children }: { children: ReactNode }) {
+  return <h3>{children}</h3>;
+}
+
+export function DialogDescription({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,7 @@
+import { InputHTMLAttributes } from "react";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export function Input(props: InputProps) {
+  return <input {...props} />;
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,54 @@
+import { ReactNode, createContext, useContext } from "react";
+
+interface SelectContextValue {
+  value?: string;
+  onValueChange?: (v: string) => void;
+}
+
+const SelectContext = createContext<SelectContextValue>({});
+
+interface SelectProps {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  children: ReactNode;
+}
+
+export function Select({ value, onValueChange, children }: SelectProps) {
+  return (
+    <SelectContext.Provider value={{ value, onValueChange }}>
+      {children}
+    </SelectContext.Provider>
+  );
+}
+
+export function SelectTrigger(
+  props: React.SelectHTMLAttributes<HTMLSelectElement>
+) {
+  const ctx = useContext(SelectContext);
+  return (
+    <select
+      {...props}
+      value={ctx.value}
+      onChange={(e) => ctx.onValueChange?.(e.target.value)}
+    >
+      {props.children}
+    </select>
+  );
+}
+
+export function SelectContent({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+export function SelectItem(
+  props: React.OptionHTMLAttributes<HTMLOptionElement> & { value: string }
+) {
+  return <option {...props}>{props.children}</option>;
+}
+
+export function SelectValue(_props: {
+  placeholder?: string;
+  className?: string;
+}) {
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a simple set of UI components under `src/components/ui`
- adjust component imports to use relative paths
- declare `recharts` in `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842a86986648328bea914f03ffdabd1