### PR TITLE
Add VS Code quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,55 @@ AECreqtrack is a lightweight requirements tracker implemented with **React** and
    node tests/csv.test.js
    ```
 
-## Using the React components
+## Getting started in Visual Studio Code
 
-AECreqtrack does not include a bundler configuration. To run the interface, place `App.tsx` and the entire `src/` directory inside an existing React project or create a new one. The example below uses [Vite](https://vitejs.dev/):
+AECreqtrack ships with reusable React components but no bundler
+configuration. The steps below show how to open the repository and run the demo
+inside a fresh Vite project.
 
-```bash
-npm create vite@latest my-app -- --template react-ts
-cd my-app
-npm install
-# Copy `App.tsx` and the `src/` directory from this repository into the Vite project's `src/`
-npm run dev
-```
+1. **Install prerequisites**
+   - [Node.js](https://nodejs.org/) 18 or newer
+   - [Git](https://git-scm.com/) for cloning the repository
+   - [Visual Studio Code](https://code.visualstudio.com/)
+2. **Clone or download the repository.** In a terminal run:
+   ```bash
+   git clone https://github.com/yourname/AECreqtrack.git
+   cd AECreqtrack
+   ```
+   Alternatively, download the ZIP archive and extract it.
+3. **Open the folder in VS Code** (`File` → `Open Folder...`).
+4. **Install dependencies** using the integrated terminal:
+   ```bash
+   npm install
+   ```
+   If npm reports a peer dependency conflict, retry with:
+   ```bash
+   npm install --legacy-peer-deps
+   ```
+5. **Compile the TypeScript sources**:
+   ```bash
+   npx tsc
+   ```
+6. **Run the included test** to verify everything works:
+   ```bash
+   node tests/csv.test.js
+   ```
+7. **Create a React project** named `aecreqtrack` where the app will run. From the terminal:
+   ```bash
+   npm create vite@latest aecreqtrack -- --template react-ts
+   cd aecreqtrack
+   npm install
+   ```
+8. **Copy `App.tsx` and the `src/` directory** from this repository into
+   `aecreqtrack/src/` (replace the generated files).
+9. **Start the development server**:
+   ```bash
+   npm run dev
+   ```
+10. Open the URL printed in the terminal (typically
+    `http://localhost:5173`) in your browser to use AECreqtrack.
 
-Open the local development URL displayed by Vite (typically `http://localhost:5173`) and you will be able to:
+Once running, you can:
 
 1. Create a project or work with the default project stored in local storage.
 2. Add new requirements using the **Add Requirement** dialog.
@@ -49,3 +85,6 @@ Open the local development URL displayed by Vite (typically `http://localhost:51
 5. Import or export a CSV file with the **Import CSV** and **Export CSV** buttons.
 
 All data is persisted in the browser, so refreshing the page keeps your progress for each project.
+
+All of these commands can be executed from the integrated terminal inside Visual
+Studio Code, making it easy for beginners to experiment with the project.

--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "description": "Lightweight requirements tracker implemented with React and TypeScript.",
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node tests/csv.test.js",
-  	"dev": "vite",
-  "build": "vite build",
-  "preview": "vite preview"
+    "test": "npm run build && node tests/csv.test.js"
   },
   "dependencies": {
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "lucide-react": "^0.355.0",
     "recharts": "^2.8.0"
   },


### PR DESCRIPTION
## Summary
- update README with a unified "Getting started" guide
- note how to resolve dependency conflict with npm
- add `react-dom` dependency and remove stray Vite scripts
- clarify project name in setup instructions

## Testing
- `npx tsc`
- `node tests/csv.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6842aceee6bc832899ffae9d6107f292