### PR TITLE
Fix Vite setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,20 @@ inside a fresh Vite project.
    `demo/src/`, replacing the files created by Vite.
 
    The imports in `App.tsx` assume it resides one level above the `src`
-   directory. After copying the file into `demo/src`, update the paths by
-   removing the leading `src/` from each import statement (for example,
-   change `"./src/components/ui/button"` to `"./components/ui/button"`).
+   directory. After copying the file into `demo/src`, run the following
+   command to automatically remove the `src/` prefix from each import:
+
+   On macOS/Linux:
+
+   ```bash
+   sed -i 's#./src/#./#g' src/App.tsx
+   ```
+
+   On Windows PowerShell:
+
+   ```powershell
+   (Get-Content src/App.tsx) -replace './src/', './' | Set-Content src/App.tsx
+   ```
 
 9. **Start the development server**:
    ```bash

--- a/README.md
+++ b/README.md
@@ -71,14 +71,21 @@ inside a fresh Vite project.
 8. **Copy `App.tsx` and the `src/` directory** from the repository root into
    `demo/src/`, replacing the files created by Vite.
 
-   The imports in `App.tsx` assume it resides one level above the `src`
-   directory. After copying the file into `demo/src`, run the following
-   command to automatically remove the `src/` prefix from each import:
-
-   On macOS/Linux:
+9. **Install the additional dependencies** used by AECreqtrack inside the
+   `demo` folder:
 
    ```bash
-   sed -i 's#./src/#./#g' src/App.tsx
+   npm install lucide-react recharts
+   ```
+
+   The imports in `App.tsx` assume it resides one level above the `src`
+   directory. After copying the file into `demo/src`, run the following command
+   from inside `demo` to remove the `src/` prefix from each import:
+
+   On macOS (BSD `sed` requires an empty backup extension) and Linux:
+
+   ```bash
+   sed -i '' -e 's#./src/#./#g' src/App.tsx
    ```
 
    On Windows PowerShell:
@@ -86,12 +93,11 @@ inside a fresh Vite project.
    ```powershell
    (Get-Content src/App.tsx) -replace './src/', './' | Set-Content src/App.tsx
    ```
-
-9. **Start the development server**:
+10. **Start the development server**:
    ```bash
    npm run dev
    ```
-10. Open the URL printed in the terminal (typically
+11. Open the URL printed in the terminal (typically
     `http://localhost:5173`) in your browser to use AECreqtrack.
 
 Once running, you can:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ inside a fresh Vite project.
 8. **Copy `App.tsx` and the `src/` directory** from the repository root into
    `demo/src/`, replacing the files created by Vite.
 
+   The imports in `App.tsx` assume it resides one level above the `src`
+   directory. After copying the file into `demo/src`, update the paths by
+   removing the leading `src/` from each import statement (for example,
+   change `"./src/components/ui/button"` to `"./components/ui/button"`).
+
 9. **Start the development server**:
    ```bash
    npm run dev


### PR DESCRIPTION
## Summary
- update README with additional step about fixing the import paths when copying `App.tsx` into a Vite demo project

## Testing
- `npx tsc`
- `node tests/csv.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68430296ffcc8328a0ebf34fd11c9c4c