### PR TITLE
Improve basic dialog styling

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -26,9 +26,13 @@ interface DialogProps {
 export function Dialog({ open, onOpenChange, children, ...props }: DialogProps) {
   return (
     <DialogContext.Provider value={{ open, setOpen: onOpenChange || (() => {}) }}>
-      <div {...props} style={{ display: open ? "block" : "none" }}>
-        {children}
-      </div>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md" {...props}>
+            {children}
+          </div>
+        </div>
+      )}
     </DialogContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- render `<Dialog>` content as a centered modal with a dimmed backdrop

## Testing
- `npx tsc`
- `node tests/csv.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684341b25a608328a04425cd04afaf94