### PR TITLE
Fix duplicate SelectTrigger definition

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -7,18 +7,7 @@ interface SelectProps {
   [key: string]: any;
 }
 
-
-export function Select({ value, onValueChange, children }: SelectProps) {
-  return (
-    <SelectContext.Provider value={{ value, onValueChange }}>
-      {children}
-    </SelectContext.Provider>
-  );
-}
-
-export function SelectTrigger(props: any) {
-  const ctx = useContext<SelectContextValue>(SelectContext as any);
-
+export function Select({ value, onValueChange, children, ...props }: SelectProps) {
   return (
     <select
       {...props}


### PR DESCRIPTION
## Summary
- prevent duplicate `SelectTrigger` by reverting to select-based component

## Testing
- `npx tsc` *(fails: JSX element type icons do not have any construct or call signatures)*
- `node tests/csv.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68435343086c83289139071ae13961be