### PR TITLE
Add modern styles with animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,7 @@ export default function App() {
   const selectValue = filterStatus ?? ALL_VALUE;
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="min-h-screen bg-gray-50 p-8 fade-in">
       <div className="mx-auto flex max-w-7xl flex-col gap-6">
         <header className="flex items-center justify-between">
           <h1 className="text-3xl font-semibold tracking-tight text-logo">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,9 +1,30 @@
 export interface ButtonProps {
-  variant?: string;
-  size?: string;
+  variant?: "default" | "outline" | "ghost";
+  size?: "sm" | "md";
+  className?: string;
   [key: string]: any;
 }
 
-export function Button({ variant, size, ...props }: ButtonProps) {
-  return <button {...props} />;
+export function Button({
+  variant = "default",
+  size = "md",
+  className = "",
+  ...props
+}: ButtonProps) {
+  let classes =
+    "inline-flex items-center justify-center font-medium rounded-md transition-colors " +
+    className;
+
+  classes += size === "sm" ? " px-2 py-1 text-sm" : " px-4 py-2";
+
+  if (variant === "outline") {
+    classes +=
+      " border border-logo text-logo hover:bg-logo hover:text-white hover:bg-logo-dark";
+  } else if (variant === "ghost") {
+    classes += " hover:bg-gray-100 dark:hover:bg-gray-800";
+  } else {
+    classes += " bg-logo text-white hover:bg-logo-dark";
+  }
+
+  return <button {...props} className={classes} />;
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,15 +1,26 @@
-export function Card({ children, ...props }: any) {
-  return <div {...props}>{children}</div>;
+export function Card({ children, className = "", ...props }: any) {
+  return (
+    <div
+      {...props}
+      className={`bg-white rounded-lg shadow-md p-4 fade-in ${className}`}
+    >
+      {children}
+    </div>
+  );
 }
 
 export function CardHeader({ children, ...props }: any) {
-  return <div {...props}>{children}</div>;
+  return <div {...props} className={`mb-4 ${props.className || ""}`}>{children}</div>;
 }
 
 export function CardTitle({ children, ...props }: any) {
-  return <h2 {...props}>{children}</h2>;
+  return (
+    <h2 {...props} className={`text-lg font-semibold ${props.className || ""}`}> 
+      {children}
+    </h2>
+  );
 }
 
 export function CardContent({ children, ...props }: any) {
-  return <div {...props}>{children}</div>;
+  return <div {...props} className={props.className}>{children}</div>;
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -26,11 +26,19 @@ interface DialogProps {
 export function Dialog({ open, onOpenChange, children, ...props }: DialogProps) {
   return (
     <DialogContext.Provider value={{ open, setOpen: onOpenChange || (() => {}) }}>
-
-      <div {...props} style={{ display: open ? "block" : "none" }}>
-        {children}
-      </div>
-
+      {open && (
+        <div
+          {...props}
+          className={`fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 fade-in ${
+            props.className || ""
+          }`}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) onOpenChange?.(false);
+          }}
+        >
+          {children}
+        </div>
+      )}
     </DialogContext.Provider>
   );
 }
@@ -66,7 +74,14 @@ interface DialogContentProps {
 }
 
 export function DialogContent({ children, ...props }: DialogContentProps) {
-  return <div {...props}>{children}</div>;
+  return (
+    <div
+      {...props}
+      className={`bg-white rounded-lg p-6 shadow-lg fade-in ${props.className || ""}`}
+    >
+      {children}
+    </div>
+  );
 }
 
 export function DialogHeader({ children, ...props }: any) {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -3,5 +3,8 @@ export interface InputProps {
 }
 
 export function Input(props: InputProps) {
-  return <input {...props} />;
+  const className =
+    "border border-gray-300 rounded-md px-2 py-1 transition-colors focus:border-logo focus:ring-logo " +
+    (props.className || "");
+  return <input {...props} className={className} />;
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -4,6 +4,7 @@ interface SelectProps {
   value?: string;
   onValueChange?: (value: string) => void;
   children: ReactNode;
+  className?: string;
   [key: string]: any;
 }
 
@@ -13,6 +14,10 @@ export function Select({ value, onValueChange, children, ...props }: SelectProps
       {...props}
       value={value}
       onChange={(e) => onValueChange?.(e.target.value)}
+      className={
+        "border border-gray-300 rounded-md px-2 py-1 transition-colors focus:border-logo focus:ring-logo " +
+        (props.className || "")
+      }
     >
       {children}
     </select>

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,3 +36,18 @@
 .dark .focus\:ring-logo:focus {
   outline-color: #66bfff;
 }
+
+/* Modern UI enhancements */
+body {
+  transition: background-color 0.2s ease-in-out;
+}
+.fade-in {
+  animation: fadeIn 0.3s ease-in-out;
+}
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.hover\\:bg-logo-dark:hover {
+  background-color: #007bb6;
+}


### PR DESCRIPTION
## Summary
- implement fade-in animations and transitions in `styles.css`
- add modern default styles to UI primitives (Button, Card, Input, Select, Dialog)
- add modal overlay and fade-in effect for dialogs
- apply fade-in animation to app container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435c06e64883288dfdef513f2a1fbe