### PR TITLE
Expose addRequirement alias in hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ All data is persisted in the browser, so refreshing the page keeps your progress
 
 All of these commands can be executed from the integrated terminal inside Visual
 Studio Code, making it easy for beginners to experiment with the project.
+
+## API
+
+The `useRequirements` hook exposes several helpers for manipulating the requirement list. It now also returns an `addRequirement` function, which is an alias for `createRequirement` and can be used in the same way to append a new requirement to the current project.

--- a/dist/src/hooks/useRequirements.js
+++ b/dist/src/hooks/useRequirements.js
@@ -92,6 +92,7 @@ function useRequirements(initial, project) {
     }, []);
     return {
         requirements,
+        addRequirement: createRequirement,
         createRequirement,
         updateRequirement,
         deleteRequirement,

--- a/src/hooks/useRequirements.ts
+++ b/src/hooks/useRequirements.ts
@@ -108,6 +108,7 @@ export function useRequirements(initial: Requirement[], project: string) {
 
   return {
     requirements,
+    addRequirement: createRequirement,
     createRequirement,
     updateRequirement,
     deleteRequirement,


### PR DESCRIPTION
## Summary
- add `addRequirement` alias returned by `useRequirements`
- document the alias in the README

## Testing
- `npx tsc`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435d6322688328ae857b67a5adf139