### PR TITLE
Add verification tab

### DIFF
--- a/dist/src/hooks/useRequirements.js
+++ b/dist/src/hooks/useRequirements.js
@@ -13,7 +13,8 @@ function useRequirements(initial, project) {
         try {
             const stored = localStorage.getItem(storageKey);
             if (stored) {
-                return JSON.parse(stored);
+                const parsed = JSON.parse(stored);
+                return parsed.map((r) => ({ verification: "", ...r }));
             }
         }
         catch (_a) {
@@ -28,7 +29,8 @@ function useRequirements(initial, project) {
         try {
             const stored = localStorage.getItem(storageKey);
             if (stored) {
-                setRequirements(JSON.parse(stored));
+                const parsed = JSON.parse(stored);
+                setRequirements(parsed.map((r) => ({ verification: "", ...r })));
             }
             else {
                 setRequirements(initial);
@@ -57,6 +59,7 @@ function useRequirements(initial, project) {
             req_id: id,
             status: types_1.DEFAULT_STATUSES[0],
             comment: "",
+            verification: "",
             ...data,
         };
         setRequirements([...requirements, newItem]);

--- a/dist/src/sampleData.js
+++ b/dist/src/sampleData.js
@@ -9,6 +9,7 @@ exports.SAMPLE_REQUIREMENTS = [
         spec_section: "1.1",
         status: "approved",
         comment: "Reviewed by QA",
+        verification: "Test plan needed",
     },
     {
         req_id: "REQ-002",
@@ -17,6 +18,7 @@ exports.SAMPLE_REQUIREMENTS = [
         spec_section: "1.2",
         status: "draft",
         comment: "Pending security review",
+        verification: "TBD",
     },
     {
         req_id: "REQ-003",
@@ -25,6 +27,7 @@ exports.SAMPLE_REQUIREMENTS = [
         spec_section: "2.1",
         status: "implemented",
         comment: "Logs available in /var/logs",
+        verification: "Manual log review",
     },
     {
         req_id: "REQ-004",
@@ -33,6 +36,7 @@ exports.SAMPLE_REQUIREMENTS = [
         spec_section: "1.1",
         status: "verified",
         comment: "Tested",
+        verification: "Unit tests",
     },
     {
         req_id: "REQ-005",
@@ -41,6 +45,7 @@ exports.SAMPLE_REQUIREMENTS = [
         spec_section: "1.1",
         status: "closed",
         comment: "Deployed",
+        verification: "Deployment check",
     },
 ];
 exports.SPEC_TREE = [

--- a/dist/src/utils/csv.js
+++ b/dist/src/utils/csv.js
@@ -11,6 +11,7 @@ function requirementsToCSV(reqs) {
         "spec_section",
         "status",
         "comment",
+        "verification",
     ];
     const rows = reqs.map((r) => [
         r.req_id,
@@ -19,6 +20,7 @@ function requirementsToCSV(reqs) {
         r.spec_section,
         r.status,
         r.comment,
+        r.verification,
     ]);
     return [headers, ...rows]
         .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
@@ -37,6 +39,7 @@ function parseCSV(text) {
         "spec_section",
         "status",
         "comment",
+        "verification",
     ];
     for (const h of requiredHeaders) {
         if (!headers.includes(h)) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { RequirementList } from "./components/RequirementList";
 import { SpecTree } from "./components/SpecTree";
 import { TraceMatrix } from "./components/TraceMatrix";
 import { Dashboard } from "./components/Dashboard";
+import { VerificationTab } from "./components/VerificationTab";
 import "./styles.css";
 
 const LOGO_BLUE = "#0097D5";
@@ -53,7 +54,13 @@ export default function App() {
   const [filterStatus, setFilterStatus] = useState<string | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [newReq, setNewReq] = useState({ title: "", description: "", spec_section: "" });
-  const [view, setView] = useState<"list" | "tree" | "matrix" | "dashboard">("list");
+  const [view, setView] = useState<
+    | "list"
+    | "tree"
+    | "matrix"
+    | "dashboard"
+    | "verification"
+  >("list");
   const [selectedSection, setSelectedSection] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -149,7 +156,9 @@ export default function App() {
             </Button>
           </div>
           <div className="space-x-2 flex items-center">
-            {(["list", "tree", "matrix", "dashboard"] as const).map((v) => (
+            {(
+              ["list", "tree", "matrix", "dashboard", "verification"] as const
+            ).map((v) => (
               <Button
                 key={v}
                 variant={view === v ? "default" : "outline"}
@@ -369,6 +378,14 @@ export default function App() {
             coveragePercent={coveragePercent}
             isReady={isReady}
             statuses={statuses}
+          />
+        )}
+
+        {view === "verification" && (
+          <VerificationTab
+            requirements={requirements}
+            onUpdate={updateRequirement}
+            logoColor={LOGO_BLUE}
           />
         )}
       </div>

--- a/src/components/VerificationTab.tsx
+++ b/src/components/VerificationTab.tsx
@@ -1,0 +1,57 @@
+import type { Requirement } from "../types";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+import { Input } from "./ui/input";
+
+interface Props {
+  requirements: Requirement[];
+  onUpdate: (id: string, patch: Partial<Requirement>) => void;
+  logoColor: string;
+}
+
+export function VerificationTab({ requirements, onUpdate, logoColor }: Props) {
+  return (
+    <Card className="overflow-x-auto">
+      <CardHeader>
+        <CardTitle className="text-logo">Verification</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-100 text-left font-medium">
+            <tr>
+              <th className="px-4 py-2 text-logo">ID</th>
+              <th className="px-4 py-2 text-logo">Title</th>
+              <th className="px-4 py-2 text-logo">Verification</th>
+            </tr>
+          </thead>
+          <tbody>
+            {requirements.map((r) => (
+              <tr key={r.req_id} className="border-b last:border-0 hover:bg-gray-50">
+                <td className="px-4 py-2 font-mono text-xs text-logo">{r.req_id}</td>
+                <td className="px-4 py-2 text-logo">{r.title}</td>
+                <td className="px-4 py-2">
+                  <Input
+                    value={r.verification}
+                    onChange={(e) => onUpdate(r.req_id, { verification: e.target.value })}
+                    className="w-full border-logo focus:ring-logo text-logo"
+                  />
+                </td>
+              </tr>
+            ))}
+            {requirements.length === 0 && (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-logo">
+                  No requirements defined.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useRequirements.ts
+++ b/src/hooks/useRequirements.ts
@@ -5,7 +5,7 @@ import { parseCSV, requirementsToCSV } from "../utils/csv";
 
 const KEY_PREFIX = "requirements_";
 
-type NewReq = Omit<Requirement, "req_id" | "status" | "comment">;
+type NewReq = Omit<Requirement, "req_id" | "status" | "comment" | "verification">;
 
 export function useRequirements(initial: Requirement[], project: string) {
   const storageKey = `${KEY_PREFIX}${project}`;
@@ -15,7 +15,8 @@ export function useRequirements(initial: Requirement[], project: string) {
     try {
       const stored = localStorage.getItem(storageKey);
       if (stored) {
-        return JSON.parse(stored) as Requirement[];
+        const parsed = JSON.parse(stored) as Requirement[];
+        return parsed.map((r) => ({ verification: "", ...r }));
       }
     } catch {
       // ignore corrupt data
@@ -29,7 +30,8 @@ export function useRequirements(initial: Requirement[], project: string) {
     try {
       const stored = localStorage.getItem(storageKey);
       if (stored) {
-        setRequirements(JSON.parse(stored) as Requirement[]);
+        const parsed = JSON.parse(stored) as Requirement[];
+        setRequirements(parsed.map((r) => ({ verification: "", ...r })));
       } else {
         setRequirements(initial);
       }
@@ -60,6 +62,7 @@ export function useRequirements(initial: Requirement[], project: string) {
         req_id: id,
         status: DEFAULT_STATUSES[0],
         comment: "",
+        verification: "",
         ...data,
       };
       setRequirements([...requirements, newItem]);

--- a/src/sampleData.ts
+++ b/src/sampleData.ts
@@ -9,6 +9,7 @@ export const SAMPLE_REQUIREMENTS: Requirement[] = [
     spec_section: "1.1",
     status: "approved",
     comment: "Reviewed by QA",
+    verification: "Test plan needed",
   },
   {
     req_id: "REQ-002",
@@ -17,6 +18,7 @@ export const SAMPLE_REQUIREMENTS: Requirement[] = [
     spec_section: "1.2",
     status: "draft",
     comment: "Pending security review",
+    verification: "TBD",
   },
   {
     req_id: "REQ-003",
@@ -25,6 +27,7 @@ export const SAMPLE_REQUIREMENTS: Requirement[] = [
     spec_section: "2.1",
     status: "implemented",
     comment: "Logs available in /var/logs",
+    verification: "Manual log review",
   },
   {
     req_id: "REQ-004",
@@ -34,6 +37,7 @@ export const SAMPLE_REQUIREMENTS: Requirement[] = [
     spec_section: "1.1",
     status: "verified",
     comment: "Tested",
+    verification: "Unit tests",
   },
   {
     req_id: "REQ-005",
@@ -42,6 +46,7 @@ export const SAMPLE_REQUIREMENTS: Requirement[] = [
     spec_section: "1.1",
     status: "closed",
     comment: "Deployed",
+    verification: "Deployment check",
   },
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,4 +15,5 @@ export interface Requirement {
   spec_section: string;
   status: Status;
   comment: string;
+  verification: string;
 }

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -9,6 +9,7 @@ export function requirementsToCSV(reqs: Requirement[]): string {
     "spec_section",
     "status",
     "comment",
+    "verification",
   ];
   const rows = reqs.map((r) => [
     r.req_id,
@@ -17,6 +18,7 @@ export function requirementsToCSV(reqs: Requirement[]): string {
     r.spec_section,
     r.status,
     r.comment,
+    r.verification,
   ]);
   return [headers, ...rows]
     .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
@@ -35,6 +37,7 @@ export function parseCSV(text: string): Requirement[] {
     "spec_section",
     "status",
     "comment",
+    "verification",
   ];
   for (const h of requiredHeaders) {
     if (!headers.includes(h)) {

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -2,7 +2,7 @@ const { requirementsToCSV, parseCSV } = require("../dist/src/utils/csv.js");
 const assert = require("assert");
 
 const sample = [
-  { req_id: "R1", title: "t", description: "d", spec_section: "s", status: "draft", comment: "c" },
+  { req_id: "R1", title: "t", description: "d", spec_section: "s", status: "draft", comment: "c", verification: "v" },
 ];
 
 const csv = requirementsToCSV(sample);


### PR DESCRIPTION
## Summary
- track verification info in Requirement type
- include verification details in sample data and CSV utils
- load/save verification info in requirements hook
- add a Verification tab view for editing verification text
- expose Verification tab in the main app
- update CSV test

## Testing
- `npx tsc` *(fails: Cannot find module 'recharts' or its corresponding type declarations)*
- `npm test` *(fails at tsc compile step)*

------
https://chatgpt.com/codex/tasks/task_e_684362fc4654832883397a57d8eb6820