### PR TITLE
Add app logo

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="15" fill="#0097D5" />
+  <text x="50" y="55" font-size="45" text-anchor="middle" fill="white" font-family="Arial">R</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,9 +113,12 @@ export default function App() {
     <div className="min-h-screen bg-gray-50 p-8 fade-in">
       <div className="mx-auto flex max-w-7xl flex-col gap-6">
         <header className="flex items-center justify-between">
-          <h1 className="text-3xl font-semibold tracking-tight text-logo">
-            Requirement Tracker
-          </h1>
+          <div className="flex items-center gap-2">
+            <img src="/logo.svg" alt="Requirement Tracker logo" className="h-8 w-8" />
+            <h1 className="text-3xl font-semibold tracking-tight text-logo">
+              Requirement Tracker
+            </h1>
+          </div>
           <div className="flex items-center gap-4">
             <Select
               value={currentProject}


### PR DESCRIPTION
## Summary
- add simple R logo SVG
- show logo image next to app title in header

## Testing
- `npx tsc` *(fails: Cannot find module 'recharts' or 'react-dom/client')*
- `node tests/csv.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684363f215fc8328b2474c7852ba4aa8