### PR TITLE
UI navigation sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { SpecTree } from "./components/SpecTree";
 import { TraceMatrix } from "./components/TraceMatrix";
 import { Dashboard } from "./components/Dashboard";
 import { VerificationTab } from "./components/VerificationTab";
+import { Sidebar, View } from "./components/Sidebar";
 import "./styles.css";
 
 const LOGO_BLUE = "#0097D5";
@@ -61,13 +62,7 @@ export default function App() {
   const [filterStatuses, setFilterStatuses] = useState<string[]>([]);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [newReq, setNewReq] = useState({ title: "", description: "", spec_section: "" });
-  const [view, setView] = useState<
-    | "list"
-    | "tree"
-    | "matrix"
-    | "dashboard"
-    | "verification"
-  >("list");
+  const [view, setView] = useState<View>("list");
   const [selectedSection, setSelectedSection] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -113,9 +108,17 @@ export default function App() {
   const selectValue = filterStatuses.length === 0 ? [ALL_VALUE] : filterStatuses;
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8 fade-in">
-      <div className="mx-auto flex max-w-7xl flex-col gap-6">
-        <header className="flex items-center justify-between">
+    <div className="min-h-screen bg-gray-50 flex">
+      <Sidebar
+        view={view}
+        setView={(v) => {
+          setView(v);
+          if (v !== "tree") setSelectedSection(null);
+        }}
+      />
+      <div className="flex-1 p-8 fade-in">
+        <div className="mx-auto flex max-w-7xl flex-col gap-6">
+          <header className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <img src="/logo.svg" alt="Requirement Tracker logo" className="h-8 w-8" />
             <h1 className="text-3xl font-semibold tracking-tight text-logo">
@@ -168,22 +171,6 @@ export default function App() {
             </Button>
           </div>
           <div className="space-x-2 flex items-center">
-            {(
-              ["list", "tree", "matrix", "dashboard", "verification"] as const
-            ).map((v) => (
-              <Button
-                key={v}
-                variant={view === v ? "default" : "outline"}
-                onClick={() => {
-                  setView(v);
-                  if (v !== "tree") setSelectedSection(null);
-                }}
-                size="sm"
-                className={view === v ? "bg-logo text-white" : ""}
-              >
-                {v.charAt(0).toUpperCase() + v.slice(1)}
-              </Button>
-            ))}
             <Button
               size="sm"
               variant="outline"
@@ -547,6 +534,7 @@ export default function App() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      </div>
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import List from "lucide-react/dist/esm/icons/list";
+import ListTree from "lucide-react/dist/esm/icons/list-tree";
+import Table2 from "lucide-react/dist/esm/icons/table-2";
+import PieChart from "lucide-react/dist/esm/icons/pie-chart";
+import CheckSquare from "lucide-react/dist/esm/icons/check-square";
+
+export type View = "list" | "tree" | "matrix" | "dashboard" | "verification";
+
+interface Props {
+  view: View;
+  setView: (v: View) => void;
+}
+
+const items: { key: View; label: string; icon: ReactNode }[] = [
+  { key: "list", label: "List", icon: <List className="h-5 w-5" /> },
+  { key: "tree", label: "Tree", icon: <ListTree className="h-5 w-5" /> },
+  { key: "matrix", label: "Matrix", icon: <Table2 className="h-5 w-5" /> },
+  { key: "dashboard", label: "Dashboard", icon: <PieChart className="h-5 w-5" /> },
+  { key: "verification", label: "Verification", icon: <CheckSquare className="h-5 w-5" /> },
+];
+
+export function Sidebar({ view, setView }: Props) {
+  return (
+    <nav className="w-48 bg-white border-r shadow-sm p-4 space-y-2">
+      {items.map((item) => (
+        <button
+          key={item.key}
+          onClick={() => setView(item.key)}
+          className={
+            "flex items-center gap-2 w-full px-3 py-2 rounded-md text-left " +
+            (view === item.key
+              ? "bg-logo text-white"
+              : "text-logo hover:bg-gray-100")
+          }
+        >
+          {item.icon}
+          <span>{item.label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add left sidebar navigation with icons for key views
- reorganize layout to use sidebar

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684367e0a7408328b3a111646cd906a7